### PR TITLE
exporting fixtures for use elsewhere

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -2,7 +2,7 @@
 var fs          = require('fs');
 var mongoose    = require('mongoose');
 var async       = require('async');
-    
+var fixtures = exports.fixtures	= {};
 
 /**
  * Clears a collection and inserts the given data as new documents
@@ -85,7 +85,6 @@ function insertCollection(modelName, data, db, callback) {
                 items.push(data[i]);
             }
         }
-        
         //Check number of tasks to run
         if (items.length == 0) {
             return callback();
@@ -118,10 +117,13 @@ function insertCollection(modelName, data, db, callback) {
  */
 function loadObject(data, db, callback) {
     callback = callback || function() {};
+
     var iterator = function(modelName, next){
+	    fixtures[modelName] = data[modelName];
         insertCollection(modelName, data[modelName], db, next);
     };
-    async.forEach(data, iterator, callback);
+    async.forEach (Object.getOwnPropertyNames(data), iterator, callback);
+
 }
 
 
@@ -136,13 +138,14 @@ function loadObject(data, db, callback) {
  */
 function loadFile(file, db, callback) { 
     callback = callback || function() {};
-    
+
+
     if (file.substr(0, 1) !== '/') {
         var parentPath = module.parent.filename.split('/');
         parentPath.pop();
         file = parentPath.join('/') + '/' + file;
     }
-    
+
     load(require(file), db, callback);
 }
 

--- a/tests/fixtures/countries.coffee
+++ b/tests/fixtures/countries.coffee
@@ -1,17 +1,14 @@
 
 ObjectID = require('mongodb').BSONNative.ObjectID
-countries = new Array()
 
-country1 =
-    _id: new ObjectID(),
-    countryCode: "CA",
-    countryName: "Canada",
-countries.push country1
-
-country2 =
+countries = 
+  country1:
+    _id: new ObjectID()
+    countryCode: "CA"
+    countryName: "Canada"
+  country2:
     _id: new ObjectID(),
     countryCode: "SE",
     countryName: "Sweden",
-countries.push country2
 
 module.exports.Country = countries

--- a/tests/mongoose_fixtures.test.js
+++ b/tests/mongoose_fixtures.test.js
@@ -46,6 +46,10 @@ describe('mongoose-fixtures test', function(){
                 expect(countries).to.be.ok();
                 expect(countries).to.be.an(Array);
                 expect(countries.length).to.be.eql(2);
+	        expect(fixturesLoader.fixtures).to.be.ok();
+	        expect (fixturesLoader.fixtures.Country).to.be.ok();
+	        expect (fixturesLoader.fixtures.Country.country1).to.be.ok();
+	        expect (fixturesLoader.fixtures.Country.country1.countryCode).to.be.ok();	
                 done();
             });
         });


### PR DESCRIPTION
I'm new to js, so if I screwed something up, apologies.  

You work made it easy to reference fields so you could do things like use objectID references in follow-on objects.  I wanted to be able to reference those things from the mocha test suite too -- I export a fixtures object from mongoose.fixtures which has all the fixture objects that were added.  

When I forked your repo, it wasn't working for me (make test failed) - I had to make a change in how you called async.forEach.  I also had to change the fixtures file so that the collections were named (and thus capable of being referenced from the test case).  

I don't know if anyone else would find this useful, but if so...

added export of fixtures objects from mongoose_fixtures
added test for new fixtures export feature
changed fixture for test to have named objects in fixture (to test)
