### PR TITLE
Change forEach(data) to use array

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -121,7 +121,7 @@ function loadObject(data, db, callback) {
     var iterator = function(modelName, next){
         insertCollection(modelName, data[modelName], db, next);
     };
-    async.forEach(data, iterator, callback);
+    async.forEach(Object.keys(data), iterator, callback);
 }
 
 


### PR DESCRIPTION
I was having unexpected results when using

```
async.forEach(data, iterator, callback)
```

forEach expects an array, and might not necessarily work with an object
