### PR TITLE
Change forEach() to forEachSeries()

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -121,7 +121,7 @@ function loadObject(data, db, callback) {
     var iterator = function(modelName, next){
         insertCollection(modelName, data[modelName], db, next);
     };
-    async.forEach(Object.keys(data), iterator, callback);
+    async.forEachSeries(Object.keys(data), iterator, callback);
 }
 
 


### PR DESCRIPTION
The loadObject() has been modified from parallel to serial. Because when the second collection of needs when the first collection is loaded in parallel will result in an error.

``` javascript
SecondModel.schema.path('ref').validate(function(value, respond) {
    FirstModel.findById(value, function(err, doc) {
        if (err || !doc) return respond(false)
        respond(true)
    })
}, 'validate fail')
```
