### PR TITLE
load fixtures in series

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -121,7 +121,7 @@ function loadObject(data, db, callback) {
     var iterator = function(modelName, next){
         insertCollection(modelName, data[modelName], db, next);
     };
-    async.forEach(Object.keys(data), iterator, callback);
+    async.forEachSeries(Object.keys(data), iterator, callback);
 }
 
 


### PR DESCRIPTION
It would be great that fixtures are loaded in series because it fails when you have a preSave having dependencies on other collections not already loaded.
