### PR TITLE
Make use of path.resolve() to fix #15

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -2,6 +2,7 @@
 var fs          = require('fs');
 var mongoose    = require('mongoose');
 var async       = require('async');
+var path        = require('path');
     
 
 /**
@@ -26,12 +27,7 @@ var load = exports.load = function(data, db, callback) {
 
     } else if (typeof data == 'string') {
 
-        //Get the absolute dir path if a relative path was given
-        if (data.substr(0, 1) !== '/') {
-            var parentPath = module.parent.filename.split('/');
-            parentPath.pop();
-            data = parentPath.join('/') + '/' + data;
-        }
+        data = path.resolve(module.parent.filename, data)
 
         //Determine if data is pointing to a file or directory
         fs.stat(data, function(err, stats) {
@@ -136,12 +132,8 @@ function loadObject(data, db, callback) {
  */
 function loadFile(file, db, callback) { 
     callback = callback || function() {};
-    
-    if (file.substr(0, 1) !== '/') {
-        var parentPath = module.parent.filename.split('/');
-        parentPath.pop();
-        file = parentPath.join('/') + '/' + file;
-    }
+
+    file = path.resolve(module.parent.filename, file)
     
     load(require(file), db, callback);
 }
@@ -158,13 +150,8 @@ function loadFile(file, db, callback) {
  */
 function loadDir(dir, db, callback) {
     callback = callback || function() {};
-    
-    //Get the absolute dir path if a relative path was given
-    if (dir.substr(0, 1) !== '/') {
-        var parentPath = module.parent.filename.split('/');
-        parentPath.pop();
-        dir = parentPath.join('/') + '/' + dir;
-    }
+
+    dir = path.resolve(module.parent.filename, dir)
     
     //Load each file in directory
     fs.readdir(dir, function(err, files){


### PR DESCRIPTION
Swapped custom-made resolver to `resolve()` method from `path` module, which doesn't break on Windows.
