### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     }
   ],
   "dependencies": {
-    "mongoose": "3.2.x",
-    "async": "0.1.x"
+    "mongoose": "3.8.x",
+    "async": "0.9.x"
   },
   "devDependencies": {
     "mocha": "1.6.x",
     "expect.js": "0.1.x",
     "coffee-script": "1.4.x",
-    "mongodb": "1.2.x"
+    "mongodb": "1.4.x"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 
-{ 
+{
   "name": "pow-mongoose-fixtures",
   "description": "Fixture loading for Mongoose on NodeJS",
   "maintainers":[
-    { 
+    {
       "name": "Charles Davison",
       "url": "https://github.com/powmedia"
     }
@@ -23,7 +23,7 @@
     "type": "git",
     "url": "http://github.com/powmedia/mongoose-fixtures.git"
   },
-  "bugs": { 
+  "bugs": {
     "url": "http://github.com/powmedia/mongoose-fixtures/issues"
   },
   "licenses": [
@@ -39,7 +39,6 @@
   "devDependencies": {
     "mocha": "1.6.x",
     "expect.js": "0.1.x",
-    "commons": "git://github.com/OpenifyIt/commons.git",
     "coffee-script": "1.4.x",
     "mongodb": "1.2.x"
   },

--- a/tests/mongoose_fixtures.test.js
+++ b/tests/mongoose_fixtures.test.js
@@ -6,17 +6,11 @@ var path = require('path');
 var expect = require('expect.js');
 var mongoose = require('mongoose');
 var fixturesLoader = require('../mongoose_fixtures');
-var MongooseInitializer = require('openifyit-commons').MongooseInitializer;
 
 describe('mongoose-fixtures test', function(){
-    before(function(done){
-        this.mongooseInitializer = new MongooseInitializer(process.env.MONGODB_URL, path.join(__dirname, './models'));
-
-        var functions = [
-            this.mongooseInitializer.openConnection,
-            this.mongooseInitializer.loadModels
-        ];
-        async.series(functions, done);
+    before(function(){
+        mongoose.connect(process.env.MONGODB_URL);
+        require('./models/country');
     });
 
     after(function(done){


### PR DESCRIPTION
Two changes in this PR:

- Remove [openifyit-commons](github.com/OpenifyIt/commons), since it doesn't exist anymore
- Update outdated dependency versions (mongoose@3.2's old bson doesn't like to build on recent nodes)
