### PR TITLE
collection.remove is deprecated.

### DIFF
--- a/mongoose_fixtures.js
+++ b/mongoose_fixtures.js
@@ -73,7 +73,7 @@ function insertCollection(modelName, data, db, callback) {
     var Model = db.model(modelName);
     
     //Clear existing collection
-    Model.collection.remove(function(err) {
+    Model.collection.deleteMany(function(err) {
         if (err) return callback(err);
         
         //Convert object to array

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "url": "https://github.com/jackdbernier"
     }
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": {
     "type": "git",
     "url": "http://github.com/powmedia/mongoose-fixtures.git"
@@ -33,7 +33,7 @@
     }
   ],
   "dependencies": {
-    "mongoose": "3.2.x",
+    "mongoose": "5.12.20",
     "async": "0.1.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   ],
   "dependencies": {
-    "mongoose": "5.12.20",
+    "mongoose": "5.13.21",
     "async": "0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Use .deleteMany instead.

Fixes: https://github.com/powmedia/mongoose-fixtures/issues/34